### PR TITLE
fix set insertion routine

### DIFF
--- a/mn/include/mn/Map.h
+++ b/mn/include/mn/Map.h
@@ -438,6 +438,9 @@ namespace mn
 		auto index = res.hash % cap;
 		auto ix = index;
 
+		size_t first_deleted_slot_index = 0;
+		bool found_first_deleted_slot = false;
+
 		// linear probing
 		while(true)
 		{
@@ -446,15 +449,32 @@ namespace mn
 			auto slot_index = hash_slot_index(slot);
 			auto slot_flags = hash_slot_flags(slot);
 
-			// this is an empty spot or deleted spot then we can use it
-			if (slot_flags == HASH_FLAGS::HASH_EMPTY ||
-				slot_flags == HASH_FLAGS::HASH_DELETED)
+			// this is an empty slot then we can use it
+			if (slot_flags == HASH_FLAGS::HASH_EMPTY)
 			{
-				break;
+				// we didn't find the key, so check the first deleted slot if we found one then
+				// reuse it
+				if (found_first_deleted_slot)
+				{
+					res.index = first_deleted_slot_index;
+				}
+				// we didn't find the key, so use the first empty slot
+				else
+				{
+					res.index = ix;
+				}
+				return res;
+			}
+
+			// this is a deleted slot we'll remember it
+			if (found_first_deleted_slot == false && slot_flags == HASH_FLAGS::HASH_DELETED)
+			{
+				first_deleted_slot_index = ix;
+				found_first_deleted_slot = true;
 			}
 
 			// this position is not empty but if it's the same value then we return it
-			if (slot_hash == res.hash && values[slot_index] == key)
+			if (slot_flags == HASH_FLAGS::HASH_USED && slot_hash == res.hash && values[slot_index] == key)
 				break;
 
 			// the position is not empty and the key is not the same
@@ -622,6 +642,7 @@ namespace mn
 		case HASH_FLAGS::HASH_USED:
 		{
 			auto index = hash_slot_index(slot);
+			assert(self.values[index] == key);
 			return &self.values[index];
 		}
 		default:
@@ -663,6 +684,8 @@ namespace mn
 		{
 			// fixup the index of the last element after swap
 			auto last_res = _set_find_slot_for_lookup(self, self.values[self.count - 1]);
+			auto value_index = hash_slot_index(self._slots[last_res.index]);
+			assert(value_index == self.count - 1);
 			self._slots[last_res.index] = hash_slot_set_index(self._slots[last_res.index], index);
 			buf_remove(self.values, index);
 		}

--- a/mn/include/mn/Map.h
+++ b/mn/include/mn/Map.h
@@ -435,7 +435,7 @@ namespace mn
 		auto cap = _slots.count;
 		if (cap == 0) return res;
 
-		auto index = res.hash % cap;
+		auto index = res.hash & (cap - 1);
 		auto ix = index;
 
 		size_t first_deleted_slot_index = 0;
@@ -492,7 +492,7 @@ namespace mn
 
 			// the position is not empty and the key is not the same
 			++ix;
-			ix %= cap;
+			ix &= (cap - 1);
 
 			// if we went full circle then we just return the cap to signal no index has been found
 			if (ix == index)
@@ -516,7 +516,7 @@ namespace mn
 		auto cap = self._slots.count;
 		if (cap == 0) return res;
 
-		auto index = res.hash % cap;
+		auto index = res.hash & (cap - 1);
 		auto ix = index;
 
 		// linear probing
@@ -544,7 +544,7 @@ namespace mn
 
 			// the position is not used or the key is not the same
 			++ix;
-			ix %= cap;
+			ix &= (cap - 1);
 
 			// if we went full circle then we just return the cap to signal no index has been found
 			if (ix == index)


### PR DESCRIPTION
set find slot for insert routine wasn't really searching to the end of the continous block of slot, it was returning on the first deleted item which is not really correct because if you have
[used, used, used(target)]
and you remove the second element
[used, deleted, used(target)]
this will exit on the second item because it's deleted and won't look at the thrid one, thus resulting in duplicate values in the set!