### PR TITLE
fix SIMD on apple M1 architecture

### DIFF
--- a/mn/CMakeLists.txt
+++ b/mn/CMakeLists.txt
@@ -176,6 +176,18 @@ target_compile_definitions(mn
 		$<$<PLATFORM_ID:Linux>:OS_LINUX=1>
 		$<$<PLATFORM_ID:Darwin>:OS_MACOS=1>)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+	target_compile_definitions(mn
+		PUBLIC
+			ARCH_X86=1
+	)
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64)|(arm32)")
+	target_compile_definitions(mn
+		PUBLIC
+			ARCH_ARM=1
+	)
+endif ()
+
 target_compile_options(mn
 	PRIVATE
 		$<$<CXX_COMPILER_ID:MSVC>:/W4>

--- a/mn/src/mn/SIMD.cpp
+++ b/mn/src/mn/SIMD.cpp
@@ -1,5 +1,8 @@
 #include "mn/SIMD.h"
 
+// SIMD is only relevant for x86 family of architectures
+#if ARCH_X86
+
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
@@ -47,7 +50,7 @@ _mn_simd_check()
 	// References
 	// http://software.intel.com/en-us/blogs/2011/04/14/is-avx-enabled/
 	// http://insufficientlycomplicated.wordpress.com/2011/11/07/detecting-intel-advanced-vector-extensions-avx-in-visual-studio/
-	
+
 	res.avx_supportted = cpuinfo[2] & (1 << 28) || false;
 	bool osxsaveSupported = cpuinfo[2] & (1 << 27) || false;
 	if (osxsaveSupported && res.avx_supportted)
@@ -71,6 +74,14 @@ _mn_simd_check()
 
 	return res;
 }
+#else
+inline static mn_simd_support
+_mn_simd_check()
+{
+	mn_simd_support res{};
+	return res;
+}
+#endif
 
 mn_simd_support
 mn_simd_support_check()


### PR DESCRIPTION
we need to first check which architecture we are on, and in case it's
x86 family of architectures then simd check function should work, on
other platforms like arm, function should return false to all SIMD
features