### PR TITLE
add support for range for loop over string runes, and fix windows utf…

### DIFF
--- a/mn/include/mn/Str.h
+++ b/mn/include/mn/Str.h
@@ -578,6 +578,91 @@ namespace mn
 	MN_EXPORT void
 	str_upper(Str& self);
 
+	struct Rune_Iterator
+	{
+		const char* it;
+		Rune r;
+
+		Rune_Iterator&
+		operator++()
+		{
+			it = rune_next(it);
+			r = rune_read(it);
+			return *this;
+		}
+
+		Rune_Iterator
+		operator++(int)
+		{
+			auto tmp = *this;
+			it = rune_next(it);
+			r = rune_read(it);
+			return tmp;
+		}
+
+		bool
+		operator==(const Rune_Iterator& other) const
+		{
+			return it == other.it;
+		}
+
+		bool
+		operator!=(const Rune_Iterator& other) const
+		{
+			return !operator==(other);
+		}
+
+		const Rune&
+		operator*() const
+		{
+			return r;
+		}
+
+		const Rune*
+		operator->() const
+		{
+			return &r;
+		}
+	};
+
+	struct Str_Runes
+	{
+		const char* begin_it;
+		const char* end_it;
+
+		Rune_Iterator
+		begin() const
+		{
+			Rune_Iterator res{};
+			res.it = begin_it;
+			res.r = rune_read(res.it);
+			return res;
+		}
+
+		Rune_Iterator
+		end() const
+		{
+			Rune_Iterator res{};
+			res.it = end_it;
+			return res;
+		}
+	};
+
+	inline static Str_Runes
+	str_runes(const Str& self)
+	{
+		return Str_Runes {
+			begin(self),
+			end(self)
+		};
+	}
+
+	inline static Str_Runes
+	str_runes(const char* str)
+	{
+		return str_runes(str_lit(str));
+	}
+
 	/**
 	 * @brief      Clone function overload for the string type
 	 *

--- a/mn/include/mn/Str.h
+++ b/mn/include/mn/Str.h
@@ -648,6 +648,7 @@ namespace mn
 		}
 	};
 
+	// returns a constant range suitable for usage in range for loops, so that you can loop over string runes
 	inline static Str_Runes
 	str_runes(const Str& self)
 	{
@@ -657,6 +658,7 @@ namespace mn
 		};
 	}
 
+	// returns a constant range suitable for usage in range for loops, so that you can loop over string runes
 	inline static Str_Runes
 	str_runes(const char* str)
 	{

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -21,3 +21,8 @@ target_include_directories(mn_unittest
 	PRIVATE
 		${CMAKE_CURRENT_SOURCE_DIR}/doctest
 )
+
+target_compile_options(mn_unittest
+	PRIVATE
+		$<$<CXX_COMPILER_ID:MSVC>:/utf-8>
+)

--- a/unittest/src/unittest_mn.cpp
+++ b/unittest/src/unittest_mn.cpp
@@ -1271,3 +1271,15 @@ TEST_CASE("arabic set")
 	CHECK(matched(prog, "mostafa") == false);
 	CHECK(matched(prog, "") == false);
 }
+
+TEST_CASE("str runes iterator")
+{
+	mn::Rune runes[] = {'M', 'o', 's', 't', 'a', 'f', 'a'};
+	size_t index = 0;
+	for (auto c: mn::str_runes("Mostafa"))
+	{
+		CHECK(c == runes[index]);
+		index++;
+	}
+	CHECK(index == 7);
+}


### PR DESCRIPTION
…8 stdout

this commit implements string rune ranges so that you can use range for
over string runes and fixes windows utf8 output to stdout and stderr
also it fixes the stdin utf8 input