### PR TITLE
Check for "." and ".." directory entries and skip over them when removing a folder.

### DIFF
--- a/mn/src/mn/linux/Path.cpp
+++ b/mn/src/mn/linux/Path.cpp
@@ -340,10 +340,14 @@ namespace mn
 		auto tmp_path = str_new();
 		mn_defer(str_free(tmp_path));
 
-		for(size_t i = 2; i < files.count; ++i)
+		for(size_t i = 0; i < files.count; ++i)
 		{
 			str_clear(tmp_path);
-			if(files[i].kind == Path_Entry::KIND_FILE)
+			if(files[i].name == "." || files[i].name == "..")
+			{
+				continue;
+			}
+			else if(files[i].kind == Path_Entry::KIND_FILE)
 			{
 				tmp_path = path_join(tmp_path, path, files[i].name);
 				if(file_remove(tmp_path) == false)

--- a/mn/src/mn/linux/Path.cpp
+++ b/mn/src/mn/linux/Path.cpp
@@ -342,12 +342,11 @@ namespace mn
 
 		for(size_t i = 0; i < files.count; ++i)
 		{
-			str_clear(tmp_path);
 			if(files[i].name == "." || files[i].name == "..")
-			{
 				continue;
-			}
-			else if(files[i].kind == Path_Entry::KIND_FILE)
+						
+			str_clear(tmp_path);
+			if(files[i].kind == Path_Entry::KIND_FILE)
 			{
 				tmp_path = path_join(tmp_path, path, files[i].name);
 				if(file_remove(tmp_path) == false)


### PR DESCRIPTION
Currently in the linux implementation of `folder_remove` we skip the first 2 entries in the folder entries, this to skip the "." and ".." entries referring to the current and parent directories respectively.

Unfortunately, the POSIX standard makes no gaurantee of the order in which it returns these names as can be seen in the NOTES section [here](https://man7.org/linux/man-pages/man3/readdir.3.html). This means we can, in some cases, skip over valid file/directories that we care about removing and instead try to remove the "." and ".." directories, in my case the function was trying to remove the "." directory which would call `folder_remove` which would then list the entries inside `path/.` which would end up in a stack overflow as `folder_remove` would keep calling itself over and over.