### PR TITLE
str_push pushes as a block, str_cmp uses memcmp when possible

### DIFF
--- a/mn/include/mn/Str.h
+++ b/mn/include/mn/Str.h
@@ -64,20 +64,25 @@ namespace mn
 		return 0;
 	}
 
-	// pushes the second string into the first one
+	// pushes the given block of bytes into the string
 	MN_EXPORT void
-	str_push(Str& self, const char* str);
+	str_block_push(Str& self, Block block);
+
+	// pushes the second string into the first one
+	inline static void
+	str_push(Str& self, const char* str)
+	{
+		if (str == nullptr)
+			return;
+		str_block_push(self, Block {(void*) str, ::strlen(str)});
+	}
 
 	// pushes the second string into the first one
 	inline static void
 	str_push(Str& self, const Str& str)
 	{
-		str_push(self, str.ptr);
+		str_block_push(self, Block {str.ptr, str.count});
 	}
-
-	// pushes the given block of bytes into the string
-	MN_EXPORT void
-	str_block_push(Str& self, Block block);
 
 	// pushes a rune into the back of the string
 	MN_EXPORT void
@@ -568,40 +573,77 @@ namespace mn
 		}
 	}
 
+	// compares two strings and returns 0 if they are equal, 1 if a > b, and -1 if a < b
+	inline static int
+	str_cmp(const Str& a, const Str& b)
+	{
+		if (a.ptr != nullptr && b.ptr != nullptr)
+		{
+			if (a.count > b.count)
+				return 1;
+			if (a.count < b.count)
+				return -1;
+			return ::memcmp(a.ptr, b.ptr, a.count);
+		}
+		else if (a.ptr == nullptr && b.ptr == nullptr)
+		{
+			return 0;
+		}
+		else if (a.ptr != nullptr && b.ptr == nullptr)
+		{
+			if (a.count == 0)
+				return 0;
+			else
+				return 1;
+		}
+		else if (a.ptr == nullptr && b.ptr != nullptr)
+		{
+			if (b.count == 0)
+				return 0;
+			else
+				return -1;
+		}
+		else
+		{
+			mn_unreachable();
+			return 0;
+		}
+	}
+
 	inline static bool
 	operator==(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) == 0;
+		return str_cmp(a, b) == 0;
 	}
 
 	inline static bool
 	operator!=(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) != 0;
+		return str_cmp(a, b) != 0;
 	}
 
 	inline static bool
 	operator<(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) < 0;
+		return str_cmp(a, b) < 0;
 	}
 
 	inline static bool
 	operator<=(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) <= 0;
+		return str_cmp(a, b) <= 0;
 	}
 
 	inline static bool
 	operator>(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) > 0;
+		return str_cmp(a, b) > 0;
 	}
 
 	inline static bool
 	operator>=(const Str& a, const Str& b)
 	{
-		return str_cmp(a.ptr, b.ptr) >= 0;
+		return str_cmp(a, b) >= 0;
 	}
 
 

--- a/mn/src/mn/Str.cpp
+++ b/mn/src/mn/Str.cpp
@@ -111,19 +111,6 @@ namespace mn
 	}
 
 	void
-	str_push(Str& self, const char* str)
-	{
-		if (str == nullptr)
-			return;
-		size_t str_len = ::strlen(str);
-		size_t self_len = self.count;
-		buf_resize(self, self.count + str_len + 1);
-		--self.count;
-		::memcpy(self.ptr + self_len, str, str_len);
-		self.ptr[self.count] = '\0';
-	}
-
-	void
 	str_block_push(Str& self, Block block)
 	{
 		size_t self_len = self.count;

--- a/unittest/src/unittest_mn.cpp
+++ b/unittest/src/unittest_mn.cpp
@@ -1366,3 +1366,10 @@ TEST_CASE("arena scopes")
 	mn::allocator_arena_restore(mn::memory::tmp(), checkpoint);
 	CHECK(name == "my name is mostafa");
 }
+
+TEST_CASE("str push blobs")
+{
+	auto str1 = mn::str_tmp("hello ");
+	mn::str_push(str1, mn::Str {nullptr, "w\0rld", 5, 5});
+	CHECK(str1 == mn::Str {nullptr, "hello w\0rld", 11, 11});
+}


### PR DESCRIPTION
Pushing a `Str` as a `Block` should be faster than pushing it as a `const char*` as the first is just `memcpy` while the 2nd is `strlen+memcpy` even if we alread know the strlen when `Str` was constructed.

Also, it's safer, in case the string contains 0-byte(s).

`str_cmp` should use `memcmp` for same purposes.