### PR TITLE
Initialize `Result::val` when it contains `Err`

### DIFF
--- a/mn/include/mn/Result.h
+++ b/mn/include/mn/Result.h
@@ -68,7 +68,9 @@ namespace mn
 		// creates a result instance from an error
 		Result(E e)
 			:err(e)
-		{}
+		{
+			::memset(&val, 0, sizeof(val));
+		}
 
 		// creates a result instance from a value
 		template<typename... TArgs>


### PR DESCRIPTION
~~Without initializing val to 0, the `destruct(Result<T, Err>)` will find no err as RAII destructed it and try to destruct invalid `Result::val`~~
tried to reproduce it but failed