### PR TITLE
Use /dev/urandom for UUID

### DIFF
--- a/mn/src/mn/linux/UUID.cpp
+++ b/mn/src/mn/linux/UUID.cpp
@@ -5,23 +5,31 @@
 
 namespace mn
 {
-	UUID
-	uuid_generate()
+	inline static void
+	_crypto_rand(mn::Block buffer)
+	{
+		ssize_t s = 0;
+		while (s < buffer.size)
+		{
+			s += getrandom(buffer.ptr, buffer.size - s, 0);
+		}
+	}
+
+	inline static UUID
+	_rand_uuid()
 	{
 		UUID self{};
-
-		// use /dev/urandom to generate random uuid
-		// /dev/urandom is faster and as-secure-as /dev/random, see https://www.2uo.de/myths-about-urandom
-		// $ man getrandom
-		// 	"Using getrandom() to read small buffers (<= 256 bytes) from the urandom source is the preferred mode of usage."
-		mn::Block buffer {&self, sizeof(self)};
-		[[maybe_unused]] const ssize_t size = getrandom(buffer.ptr, buffer.size, 0);
-		mn_assert((size_t)size == buffer.size);
-
+		_crypto_rand({&self, sizeof(self)});
 		// version 4
 		self.bytes[6] = (self.bytes[6] & 0x0f) | 0x40;
 		// variant is 10
 		self.bytes[8] = (self.bytes[8] & 0x3f) | 0x80;
 		return self;
+	}
+
+	UUID
+	uuid_generate()
+	{
+		return _rand_uuid();
 	}
 } // namespace mn

--- a/mn/src/mn/linux/UUID.cpp
+++ b/mn/src/mn/linux/UUID.cpp
@@ -15,9 +15,8 @@ namespace mn
 		// $ man getrandom
 		// 	"Using getrandom() to read small buffers (<= 256 bytes) from the urandom source is the preferred mode of usage."
 		mn::Block buffer {&self, sizeof(self)};
-		ssize_t size = getrandom(buffer.ptr, buffer.size, 0);
+		[[maybe_unused]] const ssize_t size = getrandom(buffer.ptr, buffer.size, 0);
 		mn_assert((size_t)size == buffer.size);
-		(void)size;
 
 		// version 4
 		self.bytes[6] = (self.bytes[6] & 0x0f) | 0x40;

--- a/mn/src/mn/linux/UUID.cpp
+++ b/mn/src/mn/linux/UUID.cpp
@@ -1,5 +1,4 @@
 #include "mn/UUID.h"
-#include "mn/Assert.h"
 
 #include <sys/random.h>
 

--- a/mn/src/mn/linux/UUID.cpp
+++ b/mn/src/mn/linux/UUID.cpp
@@ -7,7 +7,7 @@ namespace mn
 	inline static void
 	_crypto_rand(mn::Block buffer)
 	{
-		ssize_t s = 0;
+		size_t s = 0;
 		while (s < buffer.size)
 		{
 			s += getrandom(buffer.ptr, buffer.size - s, 0);


### PR DESCRIPTION
Faster in general, cryptographically secure as /dev/urandom, preferred (in manual) over /dev/random for small buffers

Also, /dev/random is too slow on my debian VM, I can't even run tests on my machine