### PR TITLE
Use Objc+Foundation on mac instead of unreliable env vars

### DIFF
--- a/mn/CMakeLists.txt
+++ b/mn/CMakeLists.txt
@@ -110,9 +110,11 @@ elseif(UNIX AND NOT APPLE)
 		src/mn/linux/UUID.cpp
 	)
 elseif(APPLE)
+	enable_language(OBJCXX)
 	set(SOURCE_FILES ${SOURCE_FILES}
 		src/mn/mac/Debug.cpp
 		src/mn/mac/Path.cpp
+		src/mn/mac/Path.mm
 		src/mn/mac/File.cpp
 		src/mn/mac/Thread.cpp
 		src/mn/mac/Virtual_Memory.cpp
@@ -158,6 +160,11 @@ target_link_libraries(mn
 	PUBLIC
 		fmt::fmt
 )
+
+if(APPLE)
+	find_library(FOUNDATION_LIBRARY Foundation)
+	target_link_libraries(mn PRIVATE ${FOUNDATION_LIBRARY})
+endif()
 
 # make it reflect the same structure as the one on disk
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${HEADER_FILES})

--- a/mn/src/mn/mac/Path.cpp
+++ b/mn/src/mn/mac/Path.cpp
@@ -442,6 +442,10 @@ namespace mn
 	Str
 	folder_config(Allocator allocator)
 	{
-		return str_from_c("~/Library/Preferences", allocator);
+		// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
+
+		// NOTE(mahmoud adas): if $HOME doesn't exist (why?) then config is the root one, which is still valid but requires authentication,
+		// it maybe useful to change $HOME for testing purposes, but is it always safe to read from env variable?
+		return strf(allocator, "{}/Library/Preferences", getenv("HOME"));
 	}
 }

--- a/mn/src/mn/mac/Path.cpp
+++ b/mn/src/mn/mac/Path.cpp
@@ -19,6 +19,9 @@
 
 #include <chrono>
 
+const char* get_home_path();
+const char* get_tmp_path();
+
 namespace mn
 {
 	Str
@@ -436,16 +439,13 @@ namespace mn
 	Str
 	folder_tmp(Allocator allocator)
 	{
-		return str_from_c(getenv("TMPDIR"), allocator);
+		return str_from_c(get_tmp_path(), allocator);
 	}
 
 	Str
 	folder_config(Allocator allocator)
 	{
 		// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
-
-		// NOTE(mahmoud adas): if $HOME doesn't exist (why?) then config is the root one, which is still valid but requires authentication,
-		// it maybe useful to change $HOME for testing purposes, but is it always safe to read from env variable?
-		return strf(allocator, "{}/Library/Preferences", getenv("HOME"));
+		return strf(allocator, "{}/Library/Preferences", get_home_path());
 	}
 }

--- a/mn/src/mn/mac/Path.cpp
+++ b/mn/src/mn/mac/Path.cpp
@@ -19,9 +19,6 @@
 
 #include <chrono>
 
-const char* get_home_path();
-const char* get_tmp_path();
-
 namespace mn
 {
 	Str
@@ -434,18 +431,5 @@ namespace mn
 		}
 
 		return i == files.count;
-	}
-
-	Str
-	folder_tmp(Allocator allocator)
-	{
-		return str_from_c(get_tmp_path(), allocator);
-	}
-
-	Str
-	folder_config(Allocator allocator)
-	{
-		// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
-		return strf(allocator, "{}/Library/Preferences", get_home_path());
 	}
 }

--- a/mn/src/mn/mac/Path.mm
+++ b/mn/src/mn/mac/Path.mm
@@ -18,7 +18,7 @@ namespace mn
 	{
 		// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
 		auto temp = NSTemporaryDirectory();
-		auto res = strf(allocator, "{}/Library/Preferences", [temp UTF8String]);
+		auto res = path_join(str_with_allocator(allocator), [temp UTF8String], "Library", "Preferences");
 		[temp release];
 		return res;
 	}

--- a/mn/src/mn/mac/Path.mm
+++ b/mn/src/mn/mac/Path.mm
@@ -1,12 +1,22 @@
+#include "mn/Path.h"
+
 #import <Foundation/Foundation.h>
 
-const char*
-get_home_path()
+Str
+folder_tmp(Allocator allocator)
 {
-	return [NSHomeDirectory() UTF8String];
+	auto home = NSHomeDirectory();
+	auto res = str_from_c([home UTF8String], allocator);
+	[home release];
+	return res;
 }
 
-const char* get_tmp_path()
+Str
+folder_config(Allocator allocator)
 {
-	return [NSTemporaryDirectory() UTF8String];
+	// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
+	auto temp = NSTemporaryDirectory();
+	auto res = strf(allocator, "{}/Library/Preferences", [temp UTF8String]);
+	[temp release];
+	return res;
 }

--- a/mn/src/mn/mac/Path.mm
+++ b/mn/src/mn/mac/Path.mm
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+const char*
+get_home_path()
+{
+	return [NSHomeDirectory() UTF8String];
+}
+
+const char* get_tmp_path()
+{
+	return [NSTemporaryDirectory() UTF8String];
+}

--- a/mn/src/mn/mac/Path.mm
+++ b/mn/src/mn/mac/Path.mm
@@ -2,21 +2,24 @@
 
 #import <Foundation/Foundation.h>
 
-Str
-folder_tmp(Allocator allocator)
+namespace mn
 {
-	auto home = NSHomeDirectory();
-	auto res = str_from_c([home UTF8String], allocator);
-	[home release];
-	return res;
-}
+	Str
+	folder_tmp(Allocator allocator)
+	{
+		auto home = NSHomeDirectory();
+		auto res = str_from_c([home UTF8String], allocator);
+		[home release];
+		return res;
+	}
 
-Str
-folder_config(Allocator allocator)
-{
-	// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
-	auto temp = NSTemporaryDirectory();
-	auto res = strf(allocator, "{}/Library/Preferences", [temp UTF8String]);
-	[temp release];
-	return res;
+	Str
+	folder_config(Allocator allocator)
+	{
+		// NOTE(mahmoud adas): we can't use `~` becausee macOS doesn't expand it on ::mkdir
+		auto temp = NSTemporaryDirectory();
+		auto res = strf(allocator, "{}/Library/Preferences", [temp UTF8String]);
+		[temp release];
+		return res;
+	}
 }


### PR DESCRIPTION
Caveat: requires Apple-Clang (but not GCC) because Foundation.h imports lots of headers that rely on apply specific extensions which are provided in clang

This might cause issues on repos that use mn and requires gcc, because of a bug in clang in `auto [x, y] = f(); mn_defer{free(x);};`
This would require us to compile mn with clang then switch to gcc, which i'm not sure will work because clang might produce incompatible object files

original PR not using Objc+Foundation https://github.com/MoustaphaSaad/mn/pull/107