### PR TITLE
mn::file_last_write_time should return the same result on all platforms (unixtime)

### DIFF
--- a/mn/include/mn/Path.h
+++ b/mn/include/mn/Path.h
@@ -174,11 +174,13 @@ namespace mn
 
 	// returns the time of the last write to the given file
 	// if path is not correct it will return 0
+	// the returned time is the seconds since UNIX/Linux epoch
 	MN_EXPORT int64_t
 	file_last_write_time(const char* path);
 
 	// returns the time of the last write to the given file
 	// if path is not correct it will return 0
+	// the returned time is the seconds since UNIX/Linux epoch
 	inline static int64_t
 	file_last_write_time(const mn::Str& path)
 	{

--- a/mn/src/mn/winos/Path.cpp
+++ b/mn/src/mn/winos/Path.cpp
@@ -16,6 +16,9 @@
 
 #include <chrono>
 
+#define WINDOWS_TICK 10000000
+#define SECS_BEFORE_UNIX_EPOCH 11644473600LL
+
 namespace mn
 {
 	Str
@@ -286,7 +289,13 @@ namespace mn
 		if (res == FALSE)
 			return 0;
 
-		return (int64_t(data.ftLastWriteTime.dwHighDateTime) << 32) | int64_t(data.ftLastWriteTime.dwLowDateTime);
+		// windows ticks are in 100 nanoseconds
+		int64_t windows_ticks = (int64_t(data.ftLastWriteTime.dwHighDateTime) << 32) | int64_t(data.ftLastWriteTime.dwLowDateTime);
+		// convert windows ticks from 100 nanoseconds to seconds
+		windows_ticks = windows_ticks / WINDOWS_TICK;
+		// windows epoch starts 1601-01-01T00:00:00Z and It's 11644473600 seconds before the UNIX/Linux epoch (1970-01-01T00:00:00Z)
+		// convert to unixtime
+		return windows_ticks - SECS_BEFORE_UNIX_EPOCH;
 	}
 
 	//Tip


### PR DESCRIPTION
mn::file_last_write_time returns the time in seconds since UNIX/linux epoch (1970-01-01T00:00:00Z) on mac and linux but on windows it returns the time in windows ticks (100 nanoseconds since windows epoch (1601-01-01T00:00:00Z)), they should return the same thing.